### PR TITLE
fix: Unify production and development networking configuration

### DIFF
--- a/docker-compose.production-unified.yml
+++ b/docker-compose.production-unified.yml
@@ -1,0 +1,133 @@
+version: '3.8'
+
+services:
+  # Prism Server
+  prism-server:
+    image: prism-server:latest
+    container_name: prism-server
+    restart: unless-stopped
+    env_file:
+      - .env.production
+    environment:
+      - PRISM_SERVER_HOST=0.0.0.0
+      - PRISM_SERVER_TCP_PORT=8080
+      - PRISM_SERVER_API_PORT=8081
+      - PRISM_LOGGING_LEVEL=INFO
+      - PRISM_DATABASE_PATH=/data/prism.db
+      # PowerDNS configuration - use container name for internal communication
+      - POWERDNS_API_URL=http://powerdns-server:8053/api/v1
+      - POWERDNS_ENABLED=true
+      # Email configuration
+      - EMAIL_PROVIDER=aws_ses
+      - EMAIL_FROM_ADDRESS=noreply@prism.thepaynes.ca
+      - EMAIL_FROM_NAME=Prism DNS
+      - EMAIL_ENABLED=true
+      - EMAIL_DEBUG=false
+      - AWS_REGION=us-east-1
+      - SES_USE_IAM_ROLE=false
+      - SES_CONFIGURATION_SET=prism-email-events
+      - FRONTEND_URL=https://prism.thepaynes.ca
+    volumes:
+      - ./data:/data
+      - ./config:/app/config
+    ports:
+      - "8080:8080"  # TCP server for client connections
+      - "8081:8081"  # REST API for health checks
+    networks:
+      - prism-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # Nginx Web Server
+  nginx:
+    image: prism-web:latest
+    container_name: prism-nginx
+    restart: unless-stopped
+    ports:
+      - "8090:80"
+    depends_on:
+      - prism-server
+    environment:
+      - API_URL=http://prism-server:8081
+    networks:
+      - prism-network
+
+  # PowerDNS Database (PostgreSQL)
+  powerdns-database:
+    image: postgres:15-alpine
+    container_name: powerdns-database
+    restart: unless-stopped
+    env_file:
+      - .env.powerdns
+    environment:
+      POSTGRES_DB: ${PDNS_DB_NAME:-powerdns}
+      POSTGRES_USER: ${PDNS_DB_USER:-powerdns}
+      POSTGRES_PASSWORD: ${PDNS_DB_PASSWORD:-changeme}
+    volumes:
+      - powerdns-db-data:/var/lib/postgresql/data
+      - ./powerdns/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+    ports:
+      - "5433:5432"  # Different port to avoid conflicts
+    networks:
+      - prism-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${PDNS_DB_USER:-powerdns}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # PowerDNS Server
+  powerdns-server:
+    build:
+      context: ./powerdns
+      dockerfile: Dockerfile
+    image: powerdns:local
+    container_name: powerdns-server
+    restart: unless-stopped
+    env_file:
+      - .env.powerdns
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
+      - "8053:8053"
+    environment:
+      PDNS_API_KEY: ${PDNS_API_KEY:-changeme}
+      PDNS_DB_HOST: powerdns-database
+      PDNS_DB_PORT: 5432
+      PDNS_DB_NAME: ${PDNS_DB_NAME:-powerdns}
+      PDNS_DB_USER: ${PDNS_DB_USER:-powerdns}
+      PDNS_DB_PASSWORD: ${PDNS_DB_PASSWORD:-changeme}
+      PDNS_API_ALLOW_FROM: ${PDNS_API_ALLOW_FROM:-0.0.0.0/0,::/0}
+      PDNS_DEFAULT_ZONE: ${PDNS_DEFAULT_ZONE:-managed.prism.local}
+      # Performance tuning for production
+      PDNS_RECEIVER_THREADS: ${PDNS_RECEIVER_THREADS:-4}
+      PDNS_DISTRIBUTOR_THREADS: ${PDNS_DISTRIBUTOR_THREADS:-4}
+      PDNS_CACHE_TTL: ${PDNS_CACHE_TTL:-60}
+      # Security settings
+      PDNS_DISABLE_AXFR: ${PDNS_DISABLE_AXFR:-yes}
+      PDNS_LOG_LEVEL: ${PDNS_LOG_LEVEL:-4}
+    depends_on:
+      powerdns-database:
+        condition: service_healthy
+    networks:
+      - prism-network
+    healthcheck:
+      test: ["CMD", "pdns_control", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  powerdns-db-data:
+    driver: local
+
+networks:
+  # Single unified network for all services
+  prism-network:
+    driver: bridge
+    name: prism-network

--- a/scripts/fix-production-networking.sh
+++ b/scripts/fix-production-networking.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Fix production networking to use unified configuration
+
+set -e
+
+echo "=== Fixing Production Networking Configuration ==="
+echo "This will stop all services and restart with unified networking"
+echo ""
+
+# Step 1: Stop all current services
+echo "1. Stopping all current services..."
+docker compose -f docker-compose.production.yml down
+docker compose -f docker-compose.powerdns.yml down
+docker stop prism-server prism-nginx powerdns-server powerdns-database 2>/dev/null || true
+
+# Step 2: Remove old containers (to ensure clean state)
+echo "2. Removing old containers..."
+docker rm prism-server prism-nginx powerdns-server powerdns-database 2>/dev/null || true
+
+# Step 3: Create unified network if it doesn't exist
+echo "3. Creating unified network..."
+docker network create prism-network 2>/dev/null || echo "Network already exists"
+
+# Step 4: Start services with unified configuration
+echo "4. Starting services with unified configuration..."
+docker compose -f docker-compose.production-unified.yml up -d
+
+# Step 5: Wait for services to be healthy
+echo "5. Waiting for services to be healthy..."
+sleep 15
+
+# Step 6: Verify connectivity
+echo "6. Verifying connectivity between services..."
+echo ""
+
+# Check if PowerDNS API is accessible from Prism server
+docker exec prism-server curl -s -f http://powerdns-server:8053/api/v1/servers/localhost \
+  -H "X-API-Key: ${PDNS_API_KEY:-test-api-key-change-in-production}" \
+  && echo "✅ PowerDNS API is accessible from Prism server" \
+  || echo "❌ PowerDNS API is NOT accessible from Prism server"
+
+# Check if Prism API is healthy
+curl -s -f http://localhost:8081/api/health \
+  && echo "✅ Prism API is healthy" \
+  || echo "❌ Prism API is NOT healthy"
+
+# Step 7: Show final status
+echo ""
+echo "7. Final status:"
+docker compose -f docker-compose.production-unified.yml ps
+
+echo ""
+echo "=== Migration Complete ==="
+echo "All services should now be on the unified 'prism-network'"
+echo "Zone creation should work properly now!"


### PR DESCRIPTION
The production environment had inconsistent networking:
- Prism server was on default network
- PowerDNS was using host networking mode
- Services couldn't communicate

This fix:
- Creates unified docker-compose.production-unified.yml
- All services now use the same 'prism-network' bridge network
- Matches the local development networking approach
- Includes migration script for easy deployment

This resolves the issue where DNS zones weren't visible after creation because PowerDNS API couldn't be reached from the Prism server.

🤖 Generated with [Claude Code](https://claude.ai/code)